### PR TITLE
Define true::VERSION to work around YAML::XS bug

### DIFF
--- a/lib/true.pm
+++ b/lib/true.pm
@@ -11,6 +11,13 @@ use XSLoader;
 our $VERSION = '0.13';
 our %TRUE;
 
+# Special package to help with dependencies.
+# See NOTES in the docs.
+{
+    package true::VERSION;
+    our $VERSION = $true::VERSION;
+}
+
 XSLoader::load(__PACKAGE__, $VERSION);
 
 # XXX CopFILE(&PL_compiling) gives the wrong result here (it works in the OP checker in the XS).
@@ -151,6 +158,14 @@ Disable the "automatically return true" behaviour for the currently-compiling fi
 =head2 EXPORT
 
 None by default.
+
+=head1 NOTES
+
+Because some versions of L<YAML::XS> may interpret the key of C<true>
+as a boolean, you may have trouble declaring a dependency on true.pm.
+You can instead declare a dependency on the package C<true::VERSION>
+which will have the same version as true.pm.
+
 
 =head1 SEE ALSO
 

--- a/t/version.t
+++ b/t/version.t
@@ -1,0 +1,15 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin qw($Bin);
+use Test::More tests => 2;
+
+use lib (File::Spec->catdir($Bin, 'lib'));
+
+require true;
+
+ok $true::VERSION::VERSION,                     'true::VERSION exists';
+is $true::VERSION, $true::VERSION::VERSION,     '  same $VERSION as true';


### PR DESCRIPTION
Currently, Module::Build has issues making a dependency on true.pm because of a bug in YAML::XS.  "true: 0.13" is interpreted as the boolean true.  This causes issues with META.yml and things that try to read it.  To make matters worse, YAML::Tiny does not support quoted keys, so we can't quote it.

This makes it impossible to depend on true.pm reliably.

A work around is for true.pm to define a true::VERSION package with the same version as true.pm.  This should be enough 

YAML::XS has been informed.  https://rt.cpan.org/Ticket/Display.html?id=65662
