### PR TITLE
removed logic that makes no sense

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,6 @@ use ExtUtils::MakeMaker;
 use ExtUtils::Depends;
 use Config;
 use File::Copy 'copy';
-use File::stat;
 
 our $OPTIMIZE;
 
@@ -36,10 +35,6 @@ sub ensure_activeperl_dep_files_exist($) {
 
             next if !-f $maybe; # both files don't exist - either this one is elsewhere or we have a problem: next
 
-            my $time_want  = stat($want)->mtime;
-            my $time_maybe = stat($maybe)->mtime;
-
-            next if $time_maybe <= $time_want; # don't copy the .lib file to .a if it is older
             copy($maybe, $want); # .a is missing, but .lib exists, so just copy it over
         }
     }


### PR DESCRIPTION
The lines removed in this commit would never do anything useful, since the wanted file had to be missing in order to get there, which invalidates the idea of checking the timestamp of an existing file.

I'm not sure why i put that in there. My best guess is that i had that idea and implemented it after the wanted file was already copied, then neglected to test it with the wanted file missing.

Sorry, but to be usable this will need another release. :(
